### PR TITLE
Pass map argument to parseInt for command line usage

### DIFF
--- a/hello-compute/mod.ts
+++ b/hello-compute/mod.ts
@@ -5,7 +5,7 @@ const OVERFLOW = 0xffffffff;
 // Get some numbers from the command line, or use the default 1, 4, 3, 295.
 let numbers: Uint32Array;
 if (Deno.args.length > 0) {
-  numbers = new Uint32Array(Deno.args.map(parseInt));
+  numbers = new Uint32Array(Deno.args.map(a => parseInt(a)));
 } else {
   numbers = new Uint32Array([1, 4, 3, 295]);
 }


### PR DESCRIPTION
Fixes #5 